### PR TITLE
Renamed all references of `Trial` to `Trail`.

### DIFF
--- a/Sdl.Community.GroupShareKit.Tests.Integration/Clients/ProjectClientTests.cs
+++ b/Sdl.Community.GroupShareKit.Tests.Integration/Clients/ProjectClientTests.cs
@@ -160,12 +160,12 @@ namespace Sdl.Community.GroupShareKit.Tests.Integration.Clients
 
 	    [Theory]
 	    [InlineData("9a39ed92-2655-43a3-bbd9-efd70eeb8e36")]
-	    public async Task AuditTrial(string projectId)
+	    public async Task AuditTrail(string projectId)
 	    {
 			var groupShareClient = await Helper.GetGroupShareClient();
-		    var auditTrial = await groupShareClient.Project.AuditTrial(projectId);
+		    var auditTrail = await groupShareClient.Project.AuditTrail(projectId);
 
-			Assert.True(auditTrial?.Count>0);  
+			Assert.True(auditTrail?.Count>0);
 	    }
 
 		[Fact]

--- a/Sdl.Community.GroupShareKit/Clients/IProjectClient.cs
+++ b/Sdl.Community.GroupShareKit/Clients/IProjectClient.cs
@@ -660,6 +660,6 @@ namespace Sdl.Community.GroupShareKit.Clients
 		///  Thrown when the current user does not have permission to make the request.
 		///  </exception>
 		///  <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-		Task<IReadOnlyList<AuditTrial>> AuditTrial(string projectId);
+		Task<IReadOnlyList<AuditTrail>> AuditTrail(string projectId);
 	}
 }

--- a/Sdl.Community.GroupShareKit/Clients/ProjectClient.cs
+++ b/Sdl.Community.GroupShareKit/Clients/ProjectClient.cs
@@ -952,10 +952,10 @@ namespace Sdl.Community.GroupShareKit.Clients
 	    ///  Thrown when the current user does not have permission to make the request.
 	    ///  </exception>
 	    ///  <exception cref="ApiException">Thrown when a general API error occurs.</exception>
-		public Task<IReadOnlyList<AuditTrial>> AuditTrial(string projectId)
+		public Task<IReadOnlyList<AuditTrail>> AuditTrail(string projectId)
 	    {
 			Ensure.ArgumentNotNullOrEmptyString(projectId, "projectid");
-		    return ApiConnection.GetAll<AuditTrial>(ApiUrls.AuditTrial(projectId), null);
+		    return ApiConnection.GetAll<AuditTrail>(ApiUrls.AuditTrail(projectId), null);
 		}
 
 		#endregion

--- a/Sdl.Community.GroupShareKit/Helpers/ApiUrls.cs
+++ b/Sdl.Community.GroupShareKit/Helpers/ApiUrls.cs
@@ -745,7 +745,7 @@ namespace Sdl.Community.GroupShareKit.Helpers
 	    /// <summary>
 	    /// Returns the <see cref="Uri"/> that retries the audit trail for all the language files in the given project
 	    /// </summary>
-	    public static Uri AuditTrial(string projectId)
+	    public static Uri AuditTrail(string projectId)
 	    {
 		    return "{0}/auditTrail/languageFiles/{1}".FormatUri(CurrentProjectServerUrl, projectId);
 	    }

--- a/Sdl.Community.GroupShareKit/Models/Response/AuditTrail.cs
+++ b/Sdl.Community.GroupShareKit/Models/Response/AuditTrail.cs
@@ -2,9 +2,9 @@
 
 namespace Sdl.Community.GroupShareKit.Models.Response
 {
-    public class AuditTrial
+    public class AuditTrail
     {
 		public LanguageFileDetails LanguageFile { get; set; }
-	    public List<Trial> Trials { get; set; }
+	    public List<Trail> Trails { get; set; }
 	}
 }

--- a/Sdl.Community.GroupShareKit/Models/Response/AuditTrailDetails.cs
+++ b/Sdl.Community.GroupShareKit/Models/Response/AuditTrailDetails.cs
@@ -2,9 +2,9 @@
 
 namespace Sdl.Community.GroupShareKit.Models.Response
 {
-    public class AuditTrialDetails
+    public class AuditTrailDetails
     {
 	    public LanguageFileDetails LanguageFile { get; set; }
-	    public List<Trial> Trials { get; set; }
+	    public List<Trail> Trails { get; set; }
     }
 }

--- a/Sdl.Community.GroupShareKit/Models/Response/Trail.cs
+++ b/Sdl.Community.GroupShareKit/Models/Response/Trail.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sdl.Community.GroupShareKit.Models.Response
 {
-    public class Trial
+    public class Trail
     {
 	    public string Action { get; set; }
 	    public string Timestamp { get; set; }


### PR DESCRIPTION
This change covers the AuditTrial class as well as associated classes such as AuditTrialDetails.

This misspelling prevented Json.NET from setting property values and consequently AuditTrial.Trials is always null.

[I have also sent the same changes in another pull request for the master branch. This pull request is for the GS2017 branch which, I assume, is the codebase which constitutes the last NuGet package prior to v2 of the package. We are not yet using GS2020.]